### PR TITLE
Bugfix in ExportController

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App;
 use App\{Guild, Item};
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
@@ -220,11 +221,11 @@ class ExportController extends Controller {
         }
 
         $locale = '';
-        if (\Illuminate\Support\Facades\App::getLocale() != 'en') {
+        if (App::getLocale() != 'en') {
             if ($subdomain == 'www') {
-                $subdomain = '.' . Illuminate\Support\Facades\App::getLocale() . '.';
+                $subdomain = '.' . App::getLocale() . '.';
             } else {
-                $locale = Illuminate\Support\Facades\App::getLocale() . '.';
+                $locale = App::getLocale() . '.';
             }
         }
 

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -220,7 +220,7 @@ class ExportController extends Controller {
         }
 
         $locale = '';
-        if (Illuminate\Support\Facades\App::getLocale() != 'en') {
+        if (\Illuminate\Support\Facades\App::getLocale() != 'en') {
             if ($subdomain == 'www') {
                 $subdomain = '.' . Illuminate\Support\Facades\App::getLocale() . '.';
             } else {
@@ -228,7 +228,7 @@ class ExportController extends Controller {
             }
         }
 
-        $csv = Cache::remember('lootTableExport:' . $expansionSlug, env('PUBLIC_EXPORT_CACHE_SECONDS', 600), function () use ($subdomain, $expansionId) {
+        $csv = Cache::remember('lootTableExport:' . $expansionSlug, env('PUBLIC_EXPORT_CACHE_SECONDS', 600), function () use ($subdomain, $expansionId, $locale) {
                 $rows = DB::select(DB::raw(
                     "SELECT
                         instances.name AS 'instance_name',

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -2,10 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App;
 use App\{Guild, Item};
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\{App, Cache, DB};
 
 class ExportController extends Controller {
     const CSV  = 'csv';
@@ -214,18 +212,18 @@ class ExportController extends Controller {
         }
 
         $subdomain = 'www';
-        if ($expansionId == 1) {
+        if ($expansionId === 1) {
             $subdomain = 'classic';
-        } else if ($expansionId == 2) {
+        } else if ($expansionId === 2) {
             $subdomain = 'tbc';
         }
 
-        $locale = '';
-        if (App::getLocale() != 'en') {
-            if ($subdomain == 'www') {
-                $subdomain = '.' . App::getLocale() . '.';
-            } else {
-                $locale = App::getLocale() . '.';
+        $locale = App::getLocale();
+        if ($locale != 'en') {
+            $locale .= '.';
+
+            if ($subdomain === 'www') {
+                $locale = ".{$locale}";
             }
         }
 


### PR DESCRIPTION
The Classic and TBC Loot Table exports were broken because of a namespace issue and a missing variable in the cache:remember closure.

For more info see: https://discord.com/channels/732998376798552210/732998377339486260/864510656299139073

**How to test:**
Export the loot tables here:
![image](https://user-images.githubusercontent.com/4224975/125471803-8051c925-2dcc-4fbb-aa16-28134640b1d5.png)
