### PR TITLE
Locale prefix messes up Wowhead item links

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App;
 use Exception;
 use App\{Guild, GuildItem, Item};
 use Illuminate\Support\Facades\{DB, Cache};
@@ -302,13 +303,11 @@ class ExportController extends Controller {
             $subdomain = 'tbc';
         }
 
-        $locale = '';
-        if (\Illuminate\Support\Facades\App::getLocale() != 'en') {
-            if ($subdomain == 'www') {
-                $subdomain = '.' . \Illuminate\Support\Facades\App::getLocale() . '.';
-            } else {
-                $locale = \Illuminate\Support\Facades\App::getLocale() . '.';
-            }
+        $locale = App::getLocale();
+        if ($locale === 'en') {
+            $locale = '';
+        } else {
+            $locale .= '.';
         }
 
         $csv = Cache::remember('lootTableExport:' . $expansionSlug, env('PUBLIC_EXPORT_CACHE_SECONDS', 600), function () use ($subdomain, $expansionId, $locale) {

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -415,13 +415,11 @@ class ItemController extends Controller
             $domain = 'tbc';
         }
 
-        $locale = '';
-        if (App::getLocale() != 'en') {
-            if ($domain == 'www') {
-                $domain .= '.' . App::getLocale() . '.';
-            } else {
-                $locale .= App::getLocale() . '.';
-            }
+        $locale = App::getLocale();
+        if ($locale === 'en') {
+            $locale = '';
+        } else {
+            $locale .= '.';
         }
 
         try {

--- a/resources/views/item/show.blade.php
+++ b/resources/views/item/show.blade.php
@@ -21,10 +21,12 @@
                                             $wowheadSubdomain = 'tbc';
                                         }
 
-                                        $wowheadLocale = '';
-                                        $locale = App::getLocale();
-                                        if ($locale !== "en") {
-                                            $wowheadLocale = "{$locale}.";
+                                        $wowheadLocale = App::getLocale();
+                                        if ($wowheadLocale === "en") {
+                                            $wowheadLocale = '';
+                                        }
+                                        else {
+                                            $wowheadLocale .= '.';
                                         }
                                     @endphp
 

--- a/resources/views/item/show.blade.php
+++ b/resources/views/item/show.blade.php
@@ -24,8 +24,7 @@
                                         $wowheadLocale = App::getLocale();
                                         if ($wowheadLocale === "en") {
                                             $wowheadLocale = '';
-                                        }
-                                        else {
+                                        } else {
                                             $wowheadLocale .= '.';
                                         }
                                     @endphp

--- a/resources/views/item/show.blade.php
+++ b/resources/views/item/show.blade.php
@@ -22,8 +22,9 @@
                                         }
 
                                         $wowheadLocale = '';
-                                        if (Illuminate\Support\Facades\App::getLocale()) {
-                                            $wowheadLocale = Illuminate\Support\Facades\App::getLocale() . '.';
+                                        $locale = App::getLocale();
+                                        if ($locale !== "en") {
+                                            $wowheadLocale = "{$locale}.";
                                         }
                                     @endphp
 

--- a/resources/views/partials/item.blade.php
+++ b/resources/views/partials/item.blade.php
@@ -26,13 +26,11 @@ if (isset($guild) && $guild->expansion_id) {
     }
 }
 
-$wowheadLocale = '';
-if (Illuminate\Support\Facades\App::getLocale() != 'en') {
-    if ($wowheadSubdomain == 'www') {
-        $wowheadSubdomain = '.' . Illuminate\Support\Facades\App::getLocale() . '.';
-    } else {
-        $wowheadLocale = Illuminate\Support\Facades\App::getLocale() . '.';
-    }
+$wowheadLocale = App::getLocale();
+if ($wowheadLocale === 'en') {
+    $wowheadLocale = '';
+} else {
+    $wowheadLocale .= '.';
 }
 
 if (isset($showTier) && $showTier) {


### PR DESCRIPTION
Tried my best to fix it but the wowhead url rendering is a bit of a hot mess atm. Very wet with the same or similar pieces of logic scattered about.

There are so many different approaches here (and I'm not sure what page you're on) so I went with quick'n'dirty.

- You could put some wowhead helper methods that take a locale + expansion id in `app/helpers.php`
- You could create a wowhead helper wrapper in `App\Helpers\Wowhead`
- You could create a model for it
- You could create a standalone package for it

etc. etc. etc... curious to see what you think :)

* Tested with DE/EN for all 3 subdomains (tbc/classic/www)