### PR TITLE
BUG: Raid log URIs are not stored when creating a raid

### DIFF
--- a/app/Http/Controllers/RaidController.php
+++ b/app/Http/Controllers/RaidController.php
@@ -124,6 +124,12 @@ class RaidController extends Controller
         DB::table('raid_raid_groups')->insert($newRows);
         $newRows = [];
 
+        // Add raid logs
+        if (request()->input('logs')) {
+            // Replace old logs with new ones
+            $this->syncLogs(request()->input('logs'), $raid->logs, $raid->id);
+        }
+
         AuditLog::create([
             'description'   => $currentMember->username . " created raid \"{$raid->name}\" with {$characterCount} character(s), {$instanceCount} dungeon(s), and {$raidGroupCount} raid group(s)",
             'member_id'     => $currentMember->id,


### PR DESCRIPTION
Discord post: https://discord.com/channels/732998376798552210/733019346649088121/867128418737717278

As mentioned in Discord raid log URIs weren't actually stored when creating a raid

**How to test:**
Create a raid and add one or more raid log URIs