### PR TITLE
BUG: Make sure Gargul export only includes items that are on the guild's active wishlist

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -185,8 +185,10 @@ class ExportController extends Controller {
         $characters = $guild->characters()
             ->has('outstandingItems')
             ->with([
-                'outstandingItems' => function ($query) {
-                    return $query->select('character_id', 'item_id', 'type', 'order', 'is_offspec');
+                'outstandingItems' => function ($query) use ($guild) {
+                    return $query
+                        ->where('list_number', $guild->current_wishlist_number)
+                        ->select('character_id', 'item_id', 'type', 'order', 'is_offspec');
                 }
             ])
             ->select('id', 'name')


### PR DESCRIPTION
Ever since the multiple wishlist update players have been reporting issues with items on future wishlists showing up on tooltips and in loot announcements, which causes a lot of confusion.

This update ensures that data exported only inlucudes items that are on the guild's active wishlist!