### PR TITLE
Added multiple wihslist support to the Gargul exporter

### DIFF
--- a/app/Http/Controllers/GuildController.php
+++ b/app/Http/Controllers/GuildController.php
@@ -68,7 +68,12 @@ class GuildController extends Controller
         $guild         = request()->get('guild');
         $currentMember = request()->get('currentMember');
 
-        return view('guild.export.list', ['currentMember' => $currentMember, 'guild' => $guild]);
+        return view('guild.export.list', [
+            'currentMember'     => $currentMember,
+            'guild'             => $guild,
+            'maxWishlistLists'  => CharacterLootController::MAX_WISHLIST_LISTS,
+            'wishlistNumber'    => $guild->current_wishlist_number,
+        ]);
     }
 
     /**

--- a/resources/views/guild/export/list.blade.php
+++ b/resources/views/guild/export/list.blade.php
@@ -62,14 +62,41 @@
                             <p>
                                 {!! __("Import wishlist and loot priority data into the Gargul addon. Select all ( ctrl+a ), copy ( ctrl+c ) and then paste ( ctrl+v ) in the import window (/gl wl). For more info check :curseforge_url on Curseforge. Happy lootin'!", ['curseforge_url' => "<a href='https://www.curseforge.com/wow/addons/gargul' target='_blank'>Gargul</a>"]) !!}
                             </p>
-                            <ul class="list-inline">
-                                <li class="list-inline-item">
-                                    <a href="{{ route('guild.export.gargul', ['guildId' => $guild->id, 'guildSlug' => $guild->slug]) }}" target="_blank" class="tag">
-                                        <span class="fas fa-fw fa-file-code text-muted"></span>
-                                        {{ __("Download") }}
-                                    </a>
-                                </li>
-                            </ul>
+                            <form id="itemForm" class="form-horizontal" role="form" method="POST" action="{{ route('guild.export.gargul', ['guildId' => $guild->id, 'guildSlug' => $guild->slug]) }}">
+                                {{ csrf_field() }}
+                                <ul class="list-inline">
+                                    <li class="list-inline-item">
+                                        <button class="btn btn-success" type="submit">
+                                            <span class="fas fa-file-code"></span>
+                                            {{ __("Download") }}
+                                        </button>
+                                    </li>
+                                    <li class="list-inline-item">
+                                        <div class="dropdown">
+                                            <a class="dropdown-toggle font-weight-bold text-legendary" id="wishlistDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                <span class="fas fa-fw fa-scroll-old"></span>
+                                                {{ __("Wishlists") }}
+                                            </a>
+                                            <div class="dropdown-menu" aria-labelledby="wishlistDropdown">
+                                                @for ($i = 1; $i <= $maxWishlistLists; $i++)
+                                                    <a class="dropdown-item"
+                                                       href="javascript: void(0);">
+                                                        <input type="checkbox" name="gargul_wishlist[]" id="gargul_wishlist_{{ $i }}" value="{{ $i }}" {{ $guild->current_wishlist_number == $i ? 'checked="checked"' : '' }}>
+                                                        <label for="gargul_wishlist_{{ $i }}">
+                                                            {{ __("Wishlist") }} {{ $i }}
+                                                            @if ($guild->current_wishlist_number == $i)
+                                                                <span class="text-success">{{ __('(active)') }}</span>
+                                                            @else
+                                                                <span class="text-danger">{{ __('(inactive)') }}</span>
+                                                            @endif
+                                                        </label>
+                                                    </a>
+                                                @endfor
+                                            </div>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </form>
                         </li>
 
                         <li class="p-3 mb-3 rounded">

--- a/routes/web.php
+++ b/routes/web.php
@@ -190,7 +190,7 @@ Route::group([
         Route::get('/',                                      'GuildController@showExports')               ->name('guild.exports');
         Route::get('/addon/{fileType}',                      'ExportController@exportAddonItems')         ->name('guild.export.addonItems')         ->where(['fileType' => '(csv|html)']);
         Route::get('/characters-with-items/{fileType}',      'ExportController@exportCharactersWithItems')->name('guild.export.charactersWithItems')->where(['fileType' => '(html|json)']);
-        Route::get('/gargul', 'ExportController@gargulWishlistJson')                                      ->name('guild.export.gargul');
+        Route::post('/gargul', 'ExportController@gargulWishlistJson')                                     ->name('guild.export.gargul');
         Route::get('/item-notes/{fileType}',                 'ExportController@exportItemNotes')          ->name('guild.export.itemNotes')          ->where(['fileType' => '(csv|html)']);
         Route::get('/loot/{fileType}/{lootType}',            'ExportController@exportGuildLoot')          ->name('guild.export.loot')               ->where(['fileType' => '(csv|html)', 'lootType' => '(all|prio|received|wishlist)']);
         Route::get('/raid-groups/{fileType}/{raidGroupId?}', 'ExportController@exportRaidGroups')         ->name('guild.export.raidGroups')         ->where(['fileType' => '(csv|html)']);


### PR DESCRIPTION
1) I made sure prio's are always exported regardless of which wishlist is active for the current user (as discussed in Discord)

2) Added a wishlist selector to the Gargul exporter that defaults to the currently active wishlist which looks as follows:

![image](https://user-images.githubusercontent.com/4224975/130337744-8dc33d96-9a0b-482b-952d-b4a74e938773.png)
