### PR TITLE
Optimized queries in Gargul exporter and removed n+1 issue

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -209,14 +209,16 @@ class ExportController extends Controller {
             ->has('outstandingItems')
             ->with([
                 'outstandingItems' => function ($query) use ($guild, $listNumbers) {
-                    return $query
-                        ->whereIn('list_number', $listNumbers)
-                        ->orWhere(function($query) {
-                            $query->where('type', 'prio')
-                                ->where('is_received', 0);
-                        })
-                        ->select('character_id', 'item_id', 'type', 'order', 'is_offspec');
-                }
+                    return $query->where(function($query) use ($guild, $listNumbers) {
+                        return $query
+                            ->whereIn('list_number', $listNumbers)
+                            ->orWhere(function ($query) {
+                                $query->where('type', 'prio')
+                                    ->where('is_received', 0);
+                            })
+                            ->select('character_id', 'item_id', 'type', 'order', 'is_offspec');
+                    });
+                },
             ])
             ->select('id', 'name')
             ->get();
@@ -232,7 +234,7 @@ class ExportController extends Controller {
                     continue;
                 }
 
-                $itemId = $item->item->item_id;
+                $itemId = $item->item_id;
                 $characterName = mb_strtolower($character->name);
 
                 if (!isset($wishlistData[$itemId])) {


### PR DESCRIPTION
- Query statements are now properly grouped
- Fixed an n+1 issue

**How to test**
Before checkout go to Gargul export, copy output and paste in "Original text" here:
https://www.diffchecker.com/diff

Then checkout, run again and paste new output in "Changed text"

Click "Find Difference", output should be "The two files are identical"